### PR TITLE
Check ecs meatadata DesiredStatus before proceed

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,9 @@ func configureFromFlags(ctx context.Context) {
 			log.Fatalf("Failed to fetch ECS metadata: %v", err)
 		}
 		ipAddress = metadata.Networks[0].IPv4Addresses[0] // use the first IP address
+		if metadata.DesiredStatus == "STOPPED" {
+			log.Fatalf("ECS container is being stopped, exiting")
+		}
 	}
 
 	r53 = route53.NewFromConfig(cfg)
@@ -186,7 +189,8 @@ func waitForSync(ctx context.Context, changeSet *route53.ChangeResourceRecordSet
 }
 
 type ecsMetadata struct {
-	Networks []struct {
+	DesiredStatus string `json:"DesiredStatus"`
+	Networks      []struct {
 		IPv4Addresses []string `json:"IPv4Addresses"`
 	} `json:"Networks"`
 }


### PR DESCRIPTION
If ecs container metadata has desired status of `STOPPED`, it indicates the process has been started but has missed the SIGTERM, so it should not proceed with adding the route53 record.

### Sample test log:
```
2024/10/22 04:33:09 Fetching IP Address from ECS metadata
2024/10/22 04:33:09 ECS container is being stopped, exiting
```