### PR TITLE
Retry on CNAME conflicts

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,6 +166,7 @@ func setupDNS(ctx context.Context) error {
 			}
 			// If the error is due to a conflicting CNAME, wait and try again
 			if err := SleepWithContext(ctx, 5*time.Second); err != nil {
+				log.Print("Context cancelled, stop waiting for Route53 ChangeSet to propogate")
 				return err
 			}
 			continue

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/ptr"
 )
 
 func Test_getEcsMetadata(t *testing.T) {
@@ -14,7 +21,7 @@ func Test_getEcsMetadata(t *testing.T) {
 		w.Write([]byte(`{"Name":"curl","Networks":[{"IPv4Addresses":["` + want + `"]}]}`))
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	os.Setenv("ECS_CONTAINER_METADATA_URI_V4", server.URL)
 
@@ -26,4 +33,60 @@ func Test_getEcsMetadata(t *testing.T) {
 	if got.Networks[0].IPv4Addresses[0] != want {
 		t.Errorf("getEcsMetadata() = %v, want %v", got, want)
 	}
+}
+
+type mockRoute53 struct {
+	calls    int
+	wantErrs []error
+}
+
+func (m *mockRoute53) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput, opts ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	var err error
+	if m.calls < len(m.wantErrs) {
+		err = m.wantErrs[m.calls]
+	}
+	m.calls++
+	return &route53.ChangeResourceRecordSetsOutput{
+		ChangeInfo: &types.ChangeInfo{
+			Id: aws.String("mockChangeId"),
+		},
+	}, err
+}
+
+func (m *mockRoute53) GetChange(ctx context.Context, input *route53.GetChangeInput, opts ...func(*route53.Options)) (*route53.GetChangeOutput, error) {
+	return &route53.GetChangeOutput{
+		ChangeInfo: &types.ChangeInfo{
+			Status: types.ChangeStatusInsync,
+		},
+	}, nil
+}
+
+func Test_setupDNS(t *testing.T) {
+	ctx := context.Background()
+
+	dns = "cname.nextjs.internal."
+	ipAddress = "1.2.3.4"
+
+	t.Run("success", func(t *testing.T) {
+		r53 = &mockRoute53{}
+
+		if err := setupDNS(ctx); err != nil {
+			t.Errorf("setupDNS() error = %v", err)
+		}
+	})
+
+	t.Run("retries", func(t *testing.T) {
+		r53 = &mockRoute53{
+			wantErrs: []error{&smithy.OperationError{
+				ServiceID:     "Route 53",
+				OperationName: "ChangeResourceRecordSets",
+				Err: &types.InvalidChangeBatch{
+					Message: ptr.String("[RRSet of type A with DNS name cname.nextjs.internal. is not permitted because a conflicting RRSet of type CNAME with the same DNS name already exists in zone nextjs.internal.]"),
+				},
+			}},
+		}
+		if err := setupDNS(ctx); err != nil {
+			t.Errorf("setupDNS() error = %v", err)
+		}
+	})
 }


### PR DESCRIPTION
This change retries the Route53 `ChangeResourceRecordSets` if it fails because of an existing CNAME record. The A record gets added as soon as the CNAME record disappears.